### PR TITLE
Remove c++20 temporarily

### DIFF
--- a/vj4/ui/constant/language.js
+++ b/vj4/ui/constant/language.js
@@ -5,7 +5,6 @@ export const LANG_TEXTS = {
   c11: "C11 (GCC 13.2.0)",
   cc11: "C++11 (G++ 13.2.0)",
   cc: "C++17 (G++ 13.2.0)",
-  cc20: "C++20 (G++ 13.2.0)",
   cs: "C# 7 (Mono 6.8)",
   java: "Java 8 (OpenJDK 1.8.0_422)",
   js: "JavaScript (Node.js v18.19.1)",


### PR DESCRIPTION
Removing c++20 temporarily as compile with is ~2x slower and takes ~2x more memory than c++17. Will add back later when the issue can be fixed.
