### PR TITLE
Add Codeforces-style dynamic scoring contest rule

### DIFF
--- a/vj4/handler/contest.py
+++ b/vj4/handler/contest.py
@@ -518,12 +518,15 @@ class ContestCreateHandler(contest.ContestMixin, base.Handler):
         # find next quarter
         ts = ts - ts % (15 * 60) + 15 * 60
         dt = datetime.datetime.fromtimestamp(ts, self.timezone)
+        cf_default = ','.join(str(s) for s in contest._default_cf_max_scores([1000, 1001]))
         self.render(
             "contest_edit.html",
             rules=rules,
             date_text=dt.strftime("%Y-%m-%d"),
             time_text=dt.strftime("%H:%M"),
             pids=contest._format_pids([1000, 1001]),
+            cf_default=cf_default,
+            cf_max_scores='',
         )
 
     @base.require_priv(builtin.PRIV_USER_PROFILE)
@@ -545,7 +548,8 @@ class ContestCreateHandler(contest.ContestMixin, base.Handler):
         freeze_before: int,
         hidden: bool = False,
         clarification_enabled: bool = False,
-        moderator_uids: str = ""
+        moderator_uids: str = "",
+        cf_max_scores: str = ""
     ):
         if not self.has_perm(builtin.PERM_EDIT_PROBLEM_SELF):
             self.check_perm(builtin.PERM_EDIT_PROBLEM)
@@ -573,7 +577,14 @@ class ContestCreateHandler(contest.ContestMixin, base.Handler):
                 mod_uids = [int(uid) for uid in (u.strip() for u in moderator_uids.split(',')) if uid]
             except ValueError:
                 raise error.ValidationError("moderator_uids")
-        
+
+        extra = {}
+        if rule == constant.contest.RULE_CF and cf_max_scores.strip():
+            try:
+                extra['cf_max_scores'] = [int(s.strip()) for s in cf_max_scores.split(',') if s.strip()]
+            except ValueError:
+                raise error.ValidationError("cf_max_scores")
+
         tid = await contest.add(
             self.domain_id,
             document.TYPE_CONTEST,
@@ -589,6 +600,7 @@ class ContestCreateHandler(contest.ContestMixin, base.Handler):
             hidden=hidden,
             clarification_enabled=clarification_enabled,
             moderator_uids=mod_uids,
+            **extra,
         )
         await self.hide_problems(pids)
         self.json_or_redirect(self.reverse_url("contest_detail", tid=tid))
@@ -628,6 +640,8 @@ class ContestEditHandler(contest.ContestMixin, base.Handler):
                 "contest_detail", tid=tdoc["doc_id"])),
             (self.translate("contest_edit"), None),
         )
+        cf_default = ','.join(str(s) for s in contest._default_cf_max_scores(tdoc.get("pids", [])))
+        cf_max_scores = ','.join(str(s) for s in tdoc.get("cf_max_scores", []))
         self.render(
             "contest_edit.html",
             rules=rules,
@@ -637,6 +651,8 @@ class ContestEditHandler(contest.ContestMixin, base.Handler):
             duration=duration,
             pids=contest._format_pids(tdoc["pids"]),
             path_components=path_components,
+            cf_default=cf_default,
+            cf_max_scores=cf_max_scores,
         )
 
     @base.route_argument
@@ -659,7 +675,8 @@ class ContestEditHandler(contest.ContestMixin, base.Handler):
         freeze_before: int,
         hidden: bool = False,
         clarification_enabled: bool = False,
-        moderator_uids: str = ""
+        moderator_uids: str = "",
+        cf_max_scores: str = ""
     ):
         tdoc = await contest.get(self.domain_id, document.TYPE_CONTEST, tid)
         if not self.has_perm(builtin.PERM_EDIT_PROBLEM_SELF):
@@ -690,7 +707,14 @@ class ContestEditHandler(contest.ContestMixin, base.Handler):
                 mod_uids = [int(uid) for uid in (u.strip() for u in moderator_uids.split(',')) if uid]
             except ValueError:
                 raise error.ValidationError("moderator_uids")
-        
+
+        extra = {}
+        if rule == constant.contest.RULE_CF and cf_max_scores.strip():
+            try:
+                extra['cf_max_scores'] = [int(s.strip()) for s in cf_max_scores.split(',') if s.strip()]
+            except ValueError:
+                raise error.ValidationError("cf_max_scores")
+
         await contest.edit(
             self.domain_id,
             document.TYPE_CONTEST,
@@ -706,6 +730,7 @@ class ContestEditHandler(contest.ContestMixin, base.Handler):
             hidden=hidden,
             clarification_enabled=clarification_enabled,
             moderator_uids=mod_uids,
+            **extra,
         )
         await self.hide_problems(pids)
         if (

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -46,7 +46,49 @@ def _oi_stat(tdoc, journal):
 
 
 def _cf_stat(tdoc, journal):
-  return {'score': 0, 'detail': []}
+  duration_seconds = (tdoc['end_at'] - tdoc['begin_at']).total_seconds()
+  max_scores = dict(zip(tdoc['pids'], tdoc.get('cf_max_scores', [])))
+  freeze_at = _get_freeze_at(tdoc)
+
+  naccept = collections.defaultdict(int)
+  effective = {}
+
+  for j in journal:
+    pid = j['pid']
+    if pid not in tdoc['pids']:
+      continue
+    status = j.get('status', constant.record.STATUS_WAITING)
+    if status >= constant.record.STATUS_COMPILE_ERROR:
+      continue
+    if pid in effective:
+      continue
+    if not j.get('accept'):
+      naccept[pid] += 1
+      continue
+
+    entry = copy.deepcopy(j)
+    ac_time = j['rid'].generation_time.replace(tzinfo=None)
+    max_score = max_scores.get(pid, 0)
+    if ac_time >= freeze_at:
+      entry['accept'] = False
+      entry['score'] = 0
+      entry['status_unknown'] = True
+      entry['naccept'] = naccept[pid]
+      entry['time'] = 0
+    else:
+      elapsed = (ac_time - tdoc['begin_at']).total_seconds()
+      if duration_seconds <= 0:
+        cf_score = float(max_score)
+      else:
+        decayed = max_score * (1 - elapsed / duration_seconds) - 50 * naccept[pid]
+        cf_score = max(0.3 * max_score, decayed)
+      entry['score'] = round(cf_score, 2)
+      entry['naccept'] = naccept[pid]
+      entry['time'] = elapsed
+    effective[pid] = entry
+
+  detail = list(effective.values())
+  return {'score': round(sum(d['score'] for d in detail), 2), 'detail': detail}
 
 
 def _acm_stat(tdoc, journal):

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -260,6 +260,59 @@ def _acm_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
   return rows
 
 
+def _cf_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
+  columns = []
+  columns.append({'type': 'rank', 'value': _('Rank')})
+  columns.append({'type': 'user', 'value': _('User')})
+  columns.append({'type': 'total_score', 'value': _('Total Score')})
+  for index, pid in enumerate(tdoc['pids']):
+    if is_export:
+      columns.append({'type': 'problem_score',
+                      'value': '#{0} {1}'.format(index + 1, pdict[pid]['title'])})
+    else:
+      columns.append({'type': 'problem_detail',
+                      'value': '#{0}'.format(index + 1), 'raw': pdict[pid]})
+  rows = [columns]
+  pstats = {pid: {'accept': 0, 'attempt': 0} for pid in tdoc['pids']}
+  for rank_, tsdoc in ranked_tsdocs:
+    tsddict = {item['pid']: item for item in tsdoc.get('detail', [])}
+    row = []
+    row.append({'type': 'string', 'value': rank_})
+    row.append({'type': 'user', 'value': udict[tsdoc['uid']]['uname'],
+                'raw': udict[tsdoc['uid']],
+                'dudoc': {'display_name': dudict.get(tsdoc['uid'], {}).get('display_name', '')}})
+    row.append({'type': 'string', 'value': tsdoc.get('score', 0)})
+    for pid in tdoc['pids']:
+      cell = tsddict.get(pid)
+      if cell is None:
+        col_value = '-'
+        rdoc = None
+      elif cell.get('status_unknown'):
+        col_value = '?'
+        rdoc = cell.get('rid')
+        pstats[pid]['attempt'] += cell.get('naccept', 0)
+      elif cell.get('accept'):
+        col_value = cell['score']
+        rdoc = cell.get('rid')
+        pstats[pid]['accept'] += 1
+        pstats[pid]['attempt'] += cell.get('naccept', 0) + 1
+      else:
+        col_value = '-'
+        rdoc = cell.get('rid')
+        pstats[pid]['attempt'] += cell.get('naccept', 0)
+      if is_export:
+        row.append({'type': 'string', 'value': col_value})
+      else:
+        row.append({'type': 'record', 'value': col_value, 'raw': rdoc,
+                    'uid': tsdoc['uid'], 'pid': pid})
+    rows.append(row)
+  for column in rows[0]:
+    if column['type'] == 'problem_detail':
+      pid = column['raw']['doc_id']
+      column['stats'] = '{0}/{1}'.format(pstats[pid]['accept'], pstats[pid]['attempt'])
+  return rows
+
+
 def _assignment_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
   columns = []
   columns.append({'type': 'rank', 'value': _('Rank')})

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -45,6 +45,10 @@ def _oi_stat(tdoc, journal):
   return {'score': sum(d['score'] for d in detail), 'detail': detail}
 
 
+def _cf_stat(tdoc, journal):
+  return {'score': 0, 'detail': []}
+
+
 def _acm_stat(tdoc, journal):
   naccept = collections.defaultdict(int)
   effective = {}

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -152,6 +152,10 @@ def _oi_equ_func(a, b):
   return a.get('score', 0) == b.get('score', 0)
 
 
+def _cf_equ_func(a, b):
+  return a.get('score', 0) == b.get('score', 0)
+
+
 def _oi_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
   columns = []
   columns.append({'type': 'rank', 'value': _('Rank')})
@@ -383,6 +387,12 @@ RULES = {
                                   [('accept', -1), ('time', 1)],
                                   functools.partial(enumerate, start=1),
                                   _acm_scoreboard),
+  constant.contest.RULE_CF: Rule(lambda tdoc, now: now >= tdoc['begin_at'],
+                                 lambda tdoc, now: now >= tdoc['begin_at'],
+                                 _cf_stat,
+                                 [('score', -1)],
+                                 functools.partial(rank.ranked, equ_func=_cf_equ_func),
+                                 _cf_scoreboard),
   constant.contest.RULE_ASSIGNMENT: Rule(lambda tdoc, now: now >= tdoc['begin_at'],
                                          lambda tdoc, now: False,  # TODO: show scoreboard according to assignment preference
                                          _assignment_stat,

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -430,6 +430,11 @@ async def add(domain_id: str, doc_type: int,
       raise error.ValidationError('penalty_since', 'begin_at')
     if kwargs['penalty_since'] > end_at:
       raise error.ValidationError('penalty_since', 'end_at')
+
+  if rule == constant.contest.RULE_CF:
+    if kwargs.get('cf_max_scores') is None:
+      kwargs['cf_max_scores'] = _default_cf_max_scores(pids)
+    _validate_cf_max_scores(pids, kwargs['cf_max_scores'])
   # TODO(twd2): should we check problem existance here?
   return await document.add(domain_id, content, owner_uid, doc_type,
                             title=title, rule=rule,
@@ -475,6 +480,17 @@ async def edit(domain_id: str, doc_type: int, tid: objectid.ObjectId, **kwargs):
       raise error.ValidationError('penalty_since', 'begin_at')
     if 'end_at' in kwargs and kwargs['penalty_since'] > kwargs['end_at']:
       raise error.ValidationError('penalty_since', 'end_at')
+
+  if 'cf_max_scores' in kwargs or kwargs.get('rule') == constant.contest.RULE_CF:
+    tdoc = await get(domain_id, doc_type, tid)
+    effective_rule = kwargs.get('rule', tdoc.get('rule'))
+    if effective_rule == constant.contest.RULE_CF:
+      effective_pids = kwargs.get('pids', tdoc.get('pids', []))
+      effective_scores = kwargs.get('cf_max_scores', tdoc.get('cf_max_scores'))
+      if effective_scores is None:
+        effective_scores = _default_cf_max_scores(effective_pids)
+        kwargs['cf_max_scores'] = effective_scores
+      _validate_cf_max_scores(effective_pids, effective_scores)
   return await document.set(domain_id, doc_type, tid, **kwargs)
 
 
@@ -623,6 +639,26 @@ def _parse_pids(pids_str):
 
 def _format_pids(pids_list):
   return ','.join([str(pid) for pid in pids_list])
+
+
+CF_MAX_SCORE_MIN = 100
+CF_MAX_SCORE_MAX = 10000
+
+
+def _validate_cf_max_scores(pids, cf_max_scores):
+  if not isinstance(cf_max_scores, list):
+    raise error.ValidationError('cf_max_scores')
+  if len(cf_max_scores) != len(pids):
+    raise error.ValidationError('cf_max_scores')
+  for v in cf_max_scores:
+    if isinstance(v, bool) or not isinstance(v, int):
+      raise error.ValidationError('cf_max_scores')
+    if v < CF_MAX_SCORE_MIN or v > CF_MAX_SCORE_MAX:
+      raise error.ValidationError('cf_max_scores')
+
+
+def _default_cf_max_scores(pids):
+  return [min(CF_MAX_SCORE_MAX, 500 * (i + 1)) for i in range(len(pids))]
 
 class ContestStatusMixin(object):
   @property

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -443,6 +443,10 @@ async def add(domain_id: str, doc_type: int,
   if rule == constant.contest.RULE_CF:
     if kwargs.get('cf_max_scores') is None:
       kwargs['cf_max_scores'] = _default_cf_max_scores(pids)
+    else:
+      # Intentionally fit (pad/truncate) on create too, mirroring edit, so the
+      # list always matches pids; the default ladder fills any missing slots.
+      kwargs['cf_max_scores'] = _fit_cf_max_scores(pids, kwargs['cf_max_scores'])
     _validate_cf_max_scores(pids, kwargs['cf_max_scores'])
   # TODO(twd2): should we check problem existance here?
   return await document.add(domain_id, content, owner_uid, doc_type,
@@ -498,7 +502,9 @@ async def edit(domain_id: str, doc_type: int, tid: objectid.ObjectId, **kwargs):
       effective_scores = kwargs.get('cf_max_scores', tdoc.get('cf_max_scores'))
       if effective_scores is None:
         effective_scores = _default_cf_max_scores(effective_pids)
-        kwargs['cf_max_scores'] = effective_scores
+      else:
+        effective_scores = _fit_cf_max_scores(effective_pids, effective_scores)
+      kwargs['cf_max_scores'] = effective_scores
       _validate_cf_max_scores(effective_pids, effective_scores)
   return await document.set(domain_id, doc_type, tid, **kwargs)
 
@@ -668,6 +674,15 @@ def _validate_cf_max_scores(pids, cf_max_scores):
 
 def _default_cf_max_scores(pids):
   return [min(CF_MAX_SCORE_MAX, 500 * (i + 1)) for i in range(len(pids))]
+
+
+def _fit_cf_max_scores(pids, cf_max_scores):
+  """Pad (with the default ladder) or truncate cf_max_scores to len(pids)."""
+  defaults = _default_cf_max_scores(pids)
+  fitted = list(cf_max_scores)[:len(pids)]
+  fitted += defaults[len(fitted):]
+  return fitted
+
 
 class ContestStatusMixin(object):
   @property

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -295,6 +295,7 @@ def _cf_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
     row.append({'type': 'string', 'value': tsdoc.get('score', 0)})
     for pid in tdoc['pids']:
       cell = tsddict.get(pid)
+      accepted = False
       if cell is None:
         col_value = '-'
         rdoc = None
@@ -305,17 +306,18 @@ def _cf_scoreboard(is_export, _, tdoc, ranked_tsdocs, udict, dudict, pdict):
       elif cell.get('accept'):
         col_value = cell['score']
         rdoc = cell.get('rid')
+        accepted = True
         pstats[pid]['accept'] += 1
         pstats[pid]['attempt'] += cell.get('naccept', 0) + 1
       else:
-        col_value = '-'
+        col_value = '-{0}'.format(cell.get('naccept', 0))
         rdoc = cell.get('rid')
         pstats[pid]['attempt'] += cell.get('naccept', 0)
       if is_export:
         row.append({'type': 'string', 'value': col_value})
       else:
         row.append({'type': 'record', 'value': col_value, 'raw': rdoc,
-                    'uid': tsdoc['uid'], 'pid': pid})
+                    'uid': tsdoc['uid'], 'pid': pid, 'accept': accepted})
     rows.append(row)
   for column in rows[0]:
     if column['type'] == 'problem_detail':

--- a/vj4/model/adaptor/contest.py
+++ b/vj4/model/adaptor/contest.py
@@ -46,11 +46,12 @@ def _oi_stat(tdoc, journal):
 
 
 def _cf_stat(tdoc, journal):
-  duration_seconds = (tdoc['end_at'] - tdoc['begin_at']).total_seconds()
+  duration_minutes = (tdoc['end_at'] - tdoc['begin_at']).total_seconds() / 60
   max_scores = dict(zip(tdoc['pids'], tdoc.get('cf_max_scores', [])))
   freeze_at = _get_freeze_at(tdoc)
 
   naccept = collections.defaultdict(int)
+  last_wrong = {}
   effective = {}
 
   for j in journal:
@@ -64,6 +65,7 @@ def _cf_stat(tdoc, journal):
       continue
     if not j.get('accept'):
       naccept[pid] += 1
+      last_wrong[pid] = j
       continue
 
     entry = copy.deepcopy(j)
@@ -74,21 +76,26 @@ def _cf_stat(tdoc, journal):
       entry['score'] = 0
       entry['status_unknown'] = True
       entry['naccept'] = naccept[pid]
-      entry['time'] = 0
     else:
-      elapsed = (ac_time - tdoc['begin_at']).total_seconds()
-      if duration_seconds <= 0:
-        cf_score = float(max_score)
+      elapsed_minutes = max(0, int((ac_time - tdoc['begin_at']).total_seconds() // 60))
+      if duration_minutes <= 0:
+        cf_score = max_score
       else:
-        decayed = max_score * (1 - elapsed / duration_seconds) - 50 * naccept[pid]
-        cf_score = max(0.3 * max_score, decayed)
-      entry['score'] = round(cf_score, 2)
+        deduction = int(120 * max_score * elapsed_minutes / (250 * duration_minutes))
+        cf_score = max(round(0.3 * max_score), max_score - deduction - 50 * naccept[pid])
+      entry['score'] = cf_score
       entry['naccept'] = naccept[pid]
-      entry['time'] = elapsed
     effective[pid] = entry
 
+  # Record attempted-but-unsolved problems so the scoreboard can show "-N".
+  for pid in tdoc['pids']:
+    if pid not in effective and naccept[pid] > 0:
+      j = last_wrong[pid]
+      effective[pid] = {'rid': j['rid'], 'pid': pid, 'accept': False,
+                        'score': 0, 'naccept': naccept[pid]}
+
   detail = list(effective.values())
-  return {'score': round(sum(d['score'] for d in detail), 2), 'detail': detail}
+  return {'score': sum(d['score'] for d in detail), 'detail': detail}
 
 
 def _acm_stat(tdoc, journal):

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -65,6 +65,9 @@ CF_778_AC_T0 = {'rid': objectid.ObjectId.from_datetime(NOW),
 CF_OUT_OF_CONTEST_AC = {'rid': objectid.ObjectId.from_datetime(NOW),
                         'pid': 4242, 'accept': True, 'score': 0,
                         'status': constant.record.STATUS_ACCEPTED}
+CF_777_AC_AT_100M = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(minutes=100)),
+                     'pid': 777, 'accept': True, 'score': 0,
+                     'status': constant.record.STATUS_ACCEPTED}
 
 DOMAIN_ID_DUMMY = 'dummy'
 OWNER_UID = 22
@@ -381,6 +384,11 @@ CFTDOC = {'pids': [777, 778, 779],
           'cf_max_scores': [500, 1000, 1500],
           'begin_at': NOW,
           'end_at': NOW + datetime.timedelta(hours=2)}
+CFTDOC_FROZEN_LAST_30M = {'pids': [777, 778, 779],
+                          'cf_max_scores': [500, 1000, 1500],
+                          'begin_at': NOW,
+                          'end_at': NOW + datetime.timedelta(hours=2),
+                          'freeze_before': 30}
 
 
 class CfRuleTest(unittest.TestCase):
@@ -442,6 +450,21 @@ class CfRuleTest(unittest.TestCase):
     stats = contest._cf_stat(CFTDOC, [CF_777_AC_T0, CF_777_WA_EARLY])
     self.assertEqual(stats['score'], 500)
     self.assertEqual(stats['detail'][0]['naccept'], 0)
+
+  def test_post_freeze_submission_marked_unknown(self):
+    # Contest 2h, freeze_before=30m → freeze_at = NOW+1h30m.
+    # AC at t=100min is AFTER freeze → score=0, status_unknown=True.
+    stats = contest._cf_stat(CFTDOC_FROZEN_LAST_30M, [CF_777_AC_AT_100M])
+    self.assertEqual(stats['score'], 0)
+    self.assertEqual(len(stats['detail']), 1)
+    self.assertTrue(stats['detail'][0].get('status_unknown'))
+    self.assertFalse(stats['detail'][0]['accept'])
+
+  def test_pre_freeze_submission_scored_normally(self):
+    # AC at t=0 is well before freeze → full 500.
+    stats = contest._cf_stat(CFTDOC_FROZEN_LAST_30M, [CF_777_AC_T0])
+    self.assertEqual(stats['score'], 500)
+    self.assertNotIn('status_unknown', stats['detail'][0])
 
 
 if __name__ == '__main__':

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -254,6 +254,27 @@ class AssignmentRuleTest(unittest.TestCase):
     self.assertEqual(stats['detail'], [])
 
 
+class CfMaxScoresValidationTest(unittest.TestCase):
+  def test_helper_accepts_matching_length(self):
+    contest._validate_cf_max_scores([777, 778], [500, 1000])  # no raise
+
+  def test_helper_rejects_length_mismatch(self):
+    with self.assertRaises(error.ValidationError):
+      contest._validate_cf_max_scores([777, 778, 779], [500, 1000])
+
+  def test_helper_rejects_below_min(self):
+    with self.assertRaises(error.ValidationError):
+      contest._validate_cf_max_scores([777], [50])
+
+  def test_helper_rejects_above_max(self):
+    with self.assertRaises(error.ValidationError):
+      contest._validate_cf_max_scores([777], [99999])
+
+  def test_helper_rejects_non_int(self):
+    with self.assertRaises(error.ValidationError):
+      contest._validate_cf_max_scores([777], ['oops'])
+
+
 class OuterTest(base.DatabaseTestCase):
   @base.wrap_coro
   async def test_add_get(self):

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -466,6 +466,28 @@ class CfRuleTest(unittest.TestCase):
     self.assertEqual(stats['score'], 500)
     self.assertNotIn('status_unknown', stats['detail'][0])
 
+  def test_scoreboard_basic_shape(self):
+    tdoc = {**CFTDOC, 'doc_id': 1}
+    stat = contest._cf_stat(CFTDOC, [CF_777_AC_T0, CF_778_AC_T0])
+    tsdoc = {'uid': 99, 'attend': 1, **stat}
+    ranked = [(1, tsdoc)]
+    udict = {99: {'uname': 'alice', '_id': 99}}
+    dudict = {99: {'display_name': 'Alice'}}
+    pdict = {777: {'doc_id': 777, 'title': 'P1'},
+             778: {'doc_id': 778, 'title': 'P2'},
+             779: {'doc_id': 779, 'title': 'P3'}}
+    rows = contest._cf_scoreboard(False, lambda s: s, tdoc, ranked, udict, dudict, pdict)
+    header = rows[0]
+    self.assertEqual(header[0]['type'], 'rank')
+    self.assertEqual(header[1]['type'], 'user')
+    self.assertEqual(header[2]['type'], 'total_score')
+    # 3 problems → 3 problem columns after the leading 3 fixed columns.
+    self.assertEqual(len(header), 6)
+    data_row = rows[1]
+    self.assertEqual(data_row[0]['value'], 1)         # rank
+    self.assertEqual(data_row[1]['value'], 'alice')   # user
+    self.assertEqual(data_row[2]['value'], 1500)      # total
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -42,6 +42,30 @@ SUBMIT_778_AC_LATE = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.time
 SUBMIT_780_AC = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=5)),
                  'pid': 780, 'accept': True, 'score': 1000, 'status': constant.record.STATUS_ACCEPTED}
 
+# CF rule fixtures: pid 777 has cf_max_score=500, 778 has 1000, 779 has 1500.
+# CFTDOC contest is 2 hours = 7200s starting at NOW.
+CF_777_AC_T0 = {'rid': objectid.ObjectId.from_datetime(NOW),
+                'pid': 777, 'accept': True, 'score': 0,
+                'status': constant.record.STATUS_ACCEPTED}
+CF_777_AC_END = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=7199)),
+                 'pid': 777, 'accept': True, 'score': 0,
+                 'status': constant.record.STATUS_ACCEPTED}
+CF_777_AC_HALF = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(hours=1)),
+                  'pid': 777, 'accept': True, 'score': 0,
+                  'status': constant.record.STATUS_ACCEPTED}
+CF_777_WA_EARLY = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=10)),
+                   'pid': 777, 'accept': False, 'score': 0,
+                   'status': constant.record.STATUS_WRONG_ANSWER}
+CF_777_CE_EARLY = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=5)),
+                   'pid': 777, 'accept': False, 'score': 0,
+                   'status': constant.record.STATUS_COMPILE_ERROR}
+CF_778_AC_T0 = {'rid': objectid.ObjectId.from_datetime(NOW),
+                'pid': 778, 'accept': True, 'score': 0,
+                'status': constant.record.STATUS_ACCEPTED}
+CF_OUT_OF_CONTEST_AC = {'rid': objectid.ObjectId.from_datetime(NOW),
+                        'pid': 4242, 'accept': True, 'score': 0,
+                        'status': constant.record.STATUS_ACCEPTED}
+
 DOMAIN_ID_DUMMY = 'dummy'
 OWNER_UID = 22
 TITLE = 'dummy_title'
@@ -364,6 +388,60 @@ class CfRuleTest(unittest.TestCase):
     stats = contest._cf_stat(CFTDOC, [])
     self.assertEqual(stats['score'], 0)
     self.assertEqual(stats['detail'], [])
+
+  def test_ac_at_t0_no_wa(self):
+    # Full max_score: 500 * (1 - 0/duration) - 50*0 = 500.
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_T0])
+    self.assertEqual(stats['score'], 500)
+    self.assertEqual(len(stats['detail']), 1)
+    self.assertEqual(stats['detail'][0]['pid'], 777)
+    self.assertEqual(stats['detail'][0]['score'], 500)
+    self.assertEqual(stats['detail'][0]['naccept'], 0)
+
+  def test_ac_at_end_floors_at_30pct(self):
+    # decayed = 500 * (1-1) - 0 = 0; floor = 150. Result = 150.
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_END])
+    self.assertEqual(stats['score'], 150)
+    self.assertEqual(stats['detail'][0]['score'], 150)
+
+  def test_ac_at_half_no_wa(self):
+    # 500 * (1 - 0.5) - 0 = 250.
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_HALF])
+    self.assertEqual(stats['score'], 250)
+
+  def test_ac_with_wa_subtracts_50_per_wa(self):
+    # WA at t=10s, AC at t=1h: decayed = 500*0.5 - 50*1 = 200.
+    stats = contest._cf_stat(CFTDOC, [CF_777_WA_EARLY, CF_777_AC_HALF])
+    self.assertEqual(stats['score'], 200)
+    self.assertEqual(stats['detail'][0]['naccept'], 1)
+
+  def test_compile_error_does_not_count_as_wa(self):
+    # CE at t=5s, AC at t=1h: should NOT subtract 50.
+    stats = contest._cf_stat(CFTDOC, [CF_777_CE_EARLY, CF_777_AC_HALF])
+    self.assertEqual(stats['score'], 250)
+    self.assertEqual(stats['detail'][0]['naccept'], 0)
+
+  def test_pid_outside_contest_ignored(self):
+    stats = contest._cf_stat(CFTDOC, [CF_OUT_OF_CONTEST_AC])
+    self.assertEqual(stats['score'], 0)
+    self.assertEqual(stats['detail'], [])
+
+  def test_first_ac_locks_score(self):
+    # Late AC after early AC must not overwrite (and must not be re-counted).
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_T0, CF_777_AC_END])
+    self.assertEqual(stats['score'], 500)
+
+  def test_multi_problem_sums(self):
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_T0, CF_778_AC_T0])
+    # 500 (pid 777) + 1000 (pid 778) = 1500.
+    self.assertEqual(stats['score'], 1500)
+    self.assertEqual(len(stats['detail']), 2)
+
+  def test_wa_after_ac_does_not_count(self):
+    # WA happens chronologically AFTER AC (t=10s vs t=0); AC is locked: ignored.
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_T0, CF_777_WA_EARLY])
+    self.assertEqual(stats['score'], 500)
+    self.assertEqual(stats['detail'][0]['naccept'], 0)
 
 
 if __name__ == '__main__':

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -352,5 +352,19 @@ class InnerTest(base.DatabaseTestCase):
     del tsdoc_old['rev']
     self.assertEqual(tsdoc, tsdoc_old)
 
+
+CFTDOC = {'pids': [777, 778, 779],
+          'cf_max_scores': [500, 1000, 1500],
+          'begin_at': NOW,
+          'end_at': NOW + datetime.timedelta(hours=2)}
+
+
+class CfRuleTest(unittest.TestCase):
+  def test_zero(self):
+    stats = contest._cf_stat(CFTDOC, [])
+    self.assertEqual(stats['score'], 0)
+    self.assertEqual(stats['detail'], [])
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -410,6 +410,19 @@ CFTDOC_FROZEN_LAST_30M = {'pids': [777, 778, 779],
                           'begin_at': NOW,
                           'end_at': NOW + datetime.timedelta(hours=2),
                           'freeze_before': 30}
+CFTDOC_4H = {'pids': [777, 778, 779],
+             'cf_max_scores': [500, 1000, 1500],
+             'begin_at': NOW,
+             'end_at': NOW + datetime.timedelta(hours=4)}
+CF_777_AC_90S = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=90)),
+                 'pid': 777, 'accept': True, 'score': 0,
+                 'status': constant.record.STATUS_ACCEPTED}
+CF_777_AC_119S = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=119)),
+                  'pid': 777, 'accept': True, 'score': 0,
+                  'status': constant.record.STATUS_ACCEPTED}
+CF_777_WA_LATE2 = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=20)),
+                   'pid': 777, 'accept': False, 'score': 0,
+                   'status': constant.record.STATUS_WRONG_ANSWER}
 
 
 class CfRuleTest(unittest.TestCase):
@@ -427,27 +440,28 @@ class CfRuleTest(unittest.TestCase):
     self.assertEqual(stats['detail'][0]['score'], 500)
     self.assertEqual(stats['detail'][0]['naccept'], 0)
 
-  def test_ac_at_end_floors_at_30pct(self):
-    # decayed = 500 * (1-1) - 0 = 0; floor = 150. Result = 150.
+  def test_ac_at_end_no_wa(self):
+    # t=119min (7199s floors to 119). deduction = floor(500*119/250) = 238.
+    # 500 - 238 - 0 = 262 (well above the 150 floor).
     stats = contest._cf_stat(CFTDOC, [CF_777_AC_END])
-    self.assertEqual(stats['score'], 150)
-    self.assertEqual(stats['detail'][0]['score'], 150)
+    self.assertEqual(stats['score'], 262)
+    self.assertEqual(stats['detail'][0]['score'], 262)
 
   def test_ac_at_half_no_wa(self):
-    # 500 * (1 - 0.5) - 0 = 250.
+    # t=60min. deduction = floor(500*60/250) = 120. 500 - 120 = 380.
     stats = contest._cf_stat(CFTDOC, [CF_777_AC_HALF])
-    self.assertEqual(stats['score'], 250)
+    self.assertEqual(stats['score'], 380)
 
   def test_ac_with_wa_subtracts_50_per_wa(self):
-    # WA at t=10s, AC at t=1h: decayed = 500*0.5 - 50*1 = 200.
+    # WA at t=10s, AC at t=60min: 500 - 120 - 50*1 = 330.
     stats = contest._cf_stat(CFTDOC, [CF_777_WA_EARLY, CF_777_AC_HALF])
-    self.assertEqual(stats['score'], 200)
+    self.assertEqual(stats['score'], 330)
     self.assertEqual(stats['detail'][0]['naccept'], 1)
 
   def test_compile_error_does_not_count_as_wa(self):
-    # CE at t=5s, AC at t=1h: should NOT subtract 50.
+    # CE at t=5s, AC at t=60min: CE ignored, 500 - 120 - 0 = 380.
     stats = contest._cf_stat(CFTDOC, [CF_777_CE_EARLY, CF_777_AC_HALF])
-    self.assertEqual(stats['score'], 250)
+    self.assertEqual(stats['score'], 380)
     self.assertEqual(stats['detail'][0]['naccept'], 0)
 
   def test_pid_outside_contest_ignored(self):
@@ -508,6 +522,49 @@ class CfRuleTest(unittest.TestCase):
     self.assertEqual(data_row[0]['value'], 1)         # rank
     self.assertEqual(data_row[1]['value'], 'alice')   # user
     self.assertEqual(data_row[2]['value'], 1500)      # total
+
+  def test_score_is_integer(self):
+    stats = contest._cf_stat(CFTDOC, [CF_777_AC_HALF])
+    self.assertIsInstance(stats['score'], int)
+    self.assertIsInstance(stats['detail'][0]['score'], int)
+
+  def test_floor_reached_via_wrong_submissions(self):
+    # 8 wrong submissions then an AC near t=0: 500 - 0 - 50*8 = 100,
+    # clamped up to the 30% floor = 150.
+    wa = [{'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=i + 1)),
+           'pid': 777, 'accept': False, 'score': 0,
+           'status': constant.record.STATUS_WRONG_ANSWER} for i in range(8)]
+    ac = {'rid': objectid.ObjectId.from_datetime(NOW + datetime.timedelta(seconds=9)),
+          'pid': 777, 'accept': True, 'score': 0,
+          'status': constant.record.STATUS_ACCEPTED}
+    stats = contest._cf_stat(CFTDOC, wa + [ac])
+    self.assertEqual(stats['score'], 150)
+    self.assertEqual(stats['detail'][0]['naccept'], 8)
+
+  def test_decay_is_duration_aware(self):
+    # Same problem solved 60min in. A 2h contest deducts more per minute
+    # than a 4h contest, so the 4h score is higher.
+    score_2h = contest._cf_stat(CFTDOC, [CF_777_AC_HALF])['score']
+    score_4h = contest._cf_stat(CFTDOC_4H, [CF_777_AC_HALF])['score']
+    self.assertEqual(score_2h, 380)   # floor(120*500*60/(250*120)) = 120
+    self.assertEqual(score_4h, 440)   # floor(120*500*60/(250*240)) = 60
+
+  def test_decay_steps_per_whole_minute(self):
+    # AC at 90s and at 119s both fall inside minute 1: identical score.
+    score_90 = contest._cf_stat(CFTDOC, [CF_777_AC_90S])['score']
+    score_119 = contest._cf_stat(CFTDOC, [CF_777_AC_119S])['score']
+    self.assertEqual(score_90, score_119)
+    self.assertEqual(score_90, 498)   # floor(500*1/250) = 2
+
+  def test_unsolved_problem_recorded_in_detail(self):
+    # Two WAs, no AC: the problem still appears in detail as unsolved.
+    stats = contest._cf_stat(CFTDOC, [CF_777_WA_EARLY, CF_777_WA_LATE2])
+    self.assertEqual(stats['score'], 0)
+    self.assertEqual(len(stats['detail']), 1)
+    self.assertEqual(stats['detail'][0]['pid'], 777)
+    self.assertFalse(stats['detail'][0]['accept'])
+    self.assertEqual(stats['detail'][0]['naccept'], 2)
+    self.assertEqual(stats['detail'][0]['score'], 0)
 
 
 if __name__ == '__main__':

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -274,6 +274,24 @@ class CfMaxScoresValidationTest(unittest.TestCase):
     with self.assertRaises(error.ValidationError):
       contest._validate_cf_max_scores([777], ['oops'])
 
+  def test_fit_keeps_exact_length(self):
+    self.assertEqual(contest._fit_cf_max_scores([777, 778], [500, 1000]),
+                     [500, 1000])
+
+  def test_fit_truncates_when_too_long(self):
+    self.assertEqual(contest._fit_cf_max_scores([777], [500, 1000, 1500]),
+                     [500])
+
+  def test_fit_pads_with_defaults_when_too_short(self):
+    # defaults for 3 pids are [500, 1000, 1500]; index 0 kept, 1-2 padded.
+    fitted = contest._fit_cf_max_scores([777, 778, 779], [500])
+    self.assertEqual(fitted, [500, 1000, 1500])
+    contest._validate_cf_max_scores([777, 778, 779], fitted)  # fitted output validates
+
+  def test_fit_pads_fully_when_empty(self):
+    self.assertEqual(contest._fit_cf_max_scores([777, 778], []),
+                     [500, 1000])
+
 
 class OuterTest(base.DatabaseTestCase):
   @base.wrap_coro
@@ -599,6 +617,29 @@ class CfRuleTest(unittest.TestCase):
     self.assertFalse(p1_cell['accept'])
     # P1 header column carries accept/attempt stats: 0 solved / 2 attempts.
     self.assertEqual(rows[0][3]['stats'], '0/2')
+
+
+class CfContestEditTest(base.DatabaseTestCase):
+  @base.wrap_coro
+  async def test_edit_pids_refits_cf_max_scores(self):
+    begin_at = datetime.datetime.utcnow()
+    end_at = begin_at + datetime.timedelta(hours=2)
+    tid = await contest.add(DOMAIN_ID_DUMMY, document.TYPE_CONTEST, TITLE, CONTENT,
+                            OWNER_UID, constant.contest.RULE_CF, begin_at, end_at,
+                            [777, 778, 779], cf_max_scores=[500, 1000, 1500])
+    # Remove a problem; the editor still submits the old 3-value score list.
+    # It should be truncated to match, not rejected.
+    await contest.edit(DOMAIN_ID_DUMMY, document.TYPE_CONTEST, tid,
+                       rule=constant.contest.RULE_CF, pids=[777, 778],
+                       cf_max_scores=[500, 1000, 1500])
+    tdoc = await contest.get(DOMAIN_ID_DUMMY, document.TYPE_CONTEST, tid)
+    self.assertEqual(tdoc['cf_max_scores'], [500, 1000])
+    # Add a problem back with a too-short score list; the new slot is padded.
+    await contest.edit(DOMAIN_ID_DUMMY, document.TYPE_CONTEST, tid,
+                       rule=constant.contest.RULE_CF, pids=[777, 778, 779],
+                       cf_max_scores=[500, 1000])
+    tdoc = await contest.get(DOMAIN_ID_DUMMY, document.TYPE_CONTEST, tid)
+    self.assertEqual(tdoc['cf_max_scores'], [500, 1000, 1500])
 
 
 if __name__ == '__main__':

--- a/vj4/test/test_contest.py
+++ b/vj4/test/test_contest.py
@@ -566,6 +566,40 @@ class CfRuleTest(unittest.TestCase):
     self.assertEqual(stats['detail'][0]['naccept'], 2)
     self.assertEqual(stats['detail'][0]['score'], 0)
 
+  def test_scoreboard_marks_accepted_cell(self):
+    tdoc = {**CFTDOC, 'doc_id': 1}
+    stat = contest._cf_stat(CFTDOC, [CF_777_AC_T0])
+    tsdoc = {'uid': 99, 'attend': 1, **stat}
+    udict = {99: {'uname': 'alice', '_id': 99}}
+    dudict = {99: {'display_name': 'Alice'}}
+    pdict = {777: {'doc_id': 777, 'title': 'P1'},
+             778: {'doc_id': 778, 'title': 'P2'},
+             779: {'doc_id': 779, 'title': 'P3'}}
+    rows = contest._cf_scoreboard(False, lambda s: s, tdoc, [(1, tsdoc)],
+                                  udict, dudict, pdict)
+    # columns are rank, user, total, P1, P2, P3 -> P1 cell is index 3.
+    p1_cell = rows[1][3]
+    self.assertTrue(p1_cell['accept'])
+    self.assertEqual(p1_cell['value'], 500)
+    self.assertFalse(rows[1][4]['accept'])  # P2 untouched
+
+  def test_scoreboard_shows_unsolved_attempt_count(self):
+    tdoc = {**CFTDOC, 'doc_id': 1}
+    stat = contest._cf_stat(CFTDOC, [CF_777_WA_EARLY, CF_777_WA_LATE2])
+    tsdoc = {'uid': 99, 'attend': 1, **stat}
+    udict = {99: {'uname': 'alice', '_id': 99}}
+    dudict = {99: {'display_name': 'Alice'}}
+    pdict = {777: {'doc_id': 777, 'title': 'P1'},
+             778: {'doc_id': 778, 'title': 'P2'},
+             779: {'doc_id': 779, 'title': 'P3'}}
+    rows = contest._cf_scoreboard(False, lambda s: s, tdoc, [(1, tsdoc)],
+                                  udict, dudict, pdict)
+    p1_cell = rows[1][3]
+    self.assertEqual(p1_cell['value'], '-2')
+    self.assertFalse(p1_cell['accept'])
+    # P1 header column carries accept/attempt stats: 0 solved / 2 attempts.
+    self.assertEqual(rows[0][3]['stats'], '0/2')
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/vj4/ui/common/variables.inc.styl
+++ b/vj4/ui/common/variables.inc.styl
@@ -252,6 +252,7 @@ $training-section-status-icon = {
 $contest-color = {
   'acm': #6BB67A,
   'oi': #F5C735,
+  'cf': #6EA2C7,
 }
 
 // Homework Status

--- a/vj4/ui/constant/contest.js
+++ b/vj4/ui/constant/contest.js
@@ -5,6 +5,7 @@ export const CONTEST_TYPE_HOMEWORK = 2;
 
 export const RULE_OI = 2;
 export const RULE_ACM = 3;
+export const RULE_CF = 4;
 export const RULE_ASSIGNMENT = 11;
 
 export const DOCTYPE_TO_CTYPE = {
@@ -21,6 +22,7 @@ export const CTYPE_TO_DOCTYPE = {
 export const CONTEST_RULES = [
   RULE_OI,
   RULE_ACM,
+  RULE_CF,
 ];
 
 export const HOMEWORK_RULES = [
@@ -30,6 +32,7 @@ export const HOMEWORK_RULES = [
 export const RULE_ID = {
   [RULE_OI]: 'oi',
   [RULE_ACM]: 'acm',
+  [RULE_CF]: 'cf',
   [RULE_ASSIGNMENT]: 'assignment',
 };
 attachObjectMeta(RULE_ID, 'intKey', true);
@@ -37,6 +40,7 @@ attachObjectMeta(RULE_ID, 'intKey', true);
 export const RULE_TEXTS = {
   [RULE_OI]: 'OI',
   [RULE_ACM]: 'ACM/ICPC',
+  [RULE_CF]: 'Codeforces',
   [RULE_ASSIGNMENT]: 'Assignment',
 };
 attachObjectMeta(RULE_TEXTS, 'intKey', true);

--- a/vj4/ui/templates/contest_edit.html
+++ b/vj4/ui/templates/contest_edit.html
@@ -26,6 +26,35 @@
             {{ form.form_checkbox(label='Enable Clarifications', name='clarification_enabled', value=tdoc.get('clarification_enabled', False) if tdoc is defined else False, row=False) }}
           </div>
           {{ form.form_text(columns=None, label='Problems', name='pids', value=pids) }}
+          <div id="cf-rule-fields" style="display: none;">
+            {{ form.form_text(columns=None, label='Codeforces Max Scores (comma-separated)', name='cf_max_scores', value=cf_max_scores|default('') if cf_max_scores|default('') else cf_default|default('500,1000,1500,2000,2500'), placeholder='500,1000,1500,2000,2500') }}
+            <div class="row"><div class="columns">
+              <blockquote class="note">
+                <h3>{{ _('Codeforces-style dynamic scoring') }}</h3>
+                <ul>
+                  <li>{{ _('Each problem has a maximum score that decreases over time and with each wrong attempt.') }}</li>
+                  <li>{{ _('Formula: max(0.3 &times; max_score, max_score &times; (1 &minus; elapsed/duration) &minus; 50 &times; wrong_count). Score never falls below 30%% of max.') }}</li>
+                  <li>{{ _('Wrong attempts that count: WA, TLE, MLE, RE, OLE. Compile errors do NOT count.') }}</li>
+                  <li>{{ _('Tiebreak: total score only (no penalty time).') }}</li>
+                  <li>{{ _('Ranklist freeze is supported via the "Freeze before" field.') }}</li>
+                  <li>{{ _('NOT included in this version: hacks, rooms, locked submissions, system testing.') }}</li>
+                  <li>{{ _('Enter one max score per problem in the order they appear above (between 100 and 10000). Default ladder is pre-filled.') }}</li>
+                </ul>
+              </blockquote>
+            </div></div>
+          </div>
+          <script>
+            (function(){
+              var sel = document.querySelector('select[name="rule"]');
+              var box = document.getElementById('cf-rule-fields');
+              function sync(){
+                if (!sel || !box) return;
+                box.style.display = (parseInt(sel.value, 10) === 4) ? '' : 'none';
+              }
+              if (sel) sel.addEventListener('change', sync);
+              sync();
+            })();
+          </script>
           {{ form.form_textarea(columns=None, label='Content', name='content', value=tdoc['content']|default(''), markdown=True) }}
           <div class="row"><div class="columns">
             <input type="hidden" name="csrf_token" value="{{ handler.csrf_token }}">

--- a/vj4/ui/templates/contest_edit.html
+++ b/vj4/ui/templates/contest_edit.html
@@ -33,7 +33,8 @@
                 <h3>{{ _('Codeforces-style dynamic scoring') }}</h3>
                 <ul>
                   <li>{{ _('Each problem has a maximum score that decreases over time and with each wrong attempt.') }}</li>
-                  <li>{{ _('Formula: max(0.3 &times; max_score, max_score &times; (1 &minus; elapsed/duration) &minus; 50 &times; wrong_count). Score never falls below 30%% of max.') }}</li>
+                  <li>{{ _('Formula: score = max(0.3 &times; max_score, max_score &minus; floor(120 &times; max_score &times; minutes / (250 &times; duration_minutes)) &minus; 50 &times; wrong_count).') }}</li>
+                  <li>{{ _('A problem solved at the very end is still worth about 52%% of its max; the 30%% floor is reached only through wrong attempts.') }}</li>
                   <li>{{ _('Wrong attempts that count: WA, TLE, MLE, RE, OLE. Compile errors do NOT count.') }}</li>
                   <li>{{ _('Tiebreak: total score only (no penalty time).') }}</li>
                   <li>{{ _('Ranklist freeze is supported via the "Freeze before" field.') }}</li>
@@ -49,7 +50,7 @@
               var box = document.getElementById('cf-rule-fields');
               function sync(){
                 if (!sel || !box) return;
-                box.style.display = (parseInt(sel.value, 10) === 4) ? '' : 'none';
+                box.style.display = (parseInt(sel.value, 10) === {{ vj4.constant.contest.RULE_CF }}) ? '' : 'none';
               }
               if (sel) sel.addEventListener('change', sync);
               sync();

--- a/vj4/ui/templates/contest_scoreboard.html
+++ b/vj4/ui/templates/contest_scoreboard.html
@@ -66,7 +66,9 @@
               {% if column['type'] == 'user' %}
                 {{ user.render_inline(column['raw'], column['dudoc'], badge=false, avatar=false, country=true) }}
               {% elif column['type'] == 'record' %}
-                {% if '+' in column['value']|string %}
+                {% if column.get('accept') %}
+                  {% set record_color = 'pass' %}
+                {% elif '+' in column['value']|string %}
                   {% set record_color = 'pass' %}
                 {% elif '?' in column['value']|string %}
                   {% set record_color = 'progress' %}


### PR DESCRIPTION
## Summary

Adds a new contest rule — **Codeforces-style dynamic scoring** (`RULE_CF`) — alongside the existing OI and ACM rules. Closes #44.

- Each problem has an admin-configurable maximum score (`cf_max_scores`, parallel to `pids`, validated 100–10000, default ladder pre-filled).
- A problem's value decays over the contest and with each wrong attempt, following the real Codeforces formula:
  `score = max(0.3·x, x − ⌊120·x·t / (250·d)⌋ − 50·w)` — `x` = max score, `t` = whole minutes elapsed, `d` = contest duration in minutes, `w` = wrong attempts before the first AC. Compile errors do not count as wrong attempts; the score floors at 30% of max.
- Standings render solved problems in green with their point value, attempted-but-unsolved problems as `−N`, and respect ranklist freeze (`?`).
- The contest editor gains a CF section: the max-scores field, an explanatory info card, and a rule-toggle. Editing a CF contest's problem list automatically refits `cf_max_scores` to the new problem count instead of erroring.

This branch includes a re-verification pass that corrected the time-decay formula to match real Codeforces (it previously decayed ~2× too fast), made scores integers, and completed the standings rendering for unsolved problems.

Out of scope (intentionally): hacks, rooms, locked submissions, post-contest system testing, dynamic solver-count scoring.

## Test Plan

- [ ] `python3 -m unittest vj4.test.test_contest` with MongoDB running — all pass (51 pure-logic tests verified; 7 DB-backed tests, including `CfContestEditTest`, require a MongoDB instance).
- [ ] Create a Codeforces-rule contest, attend it, submit accepted and wrong solutions; verify the standings show point scores, `−N` for unsolved attempts, and green cells for solved problems.
- [ ] Edit the contest's problem list (add/remove a problem) without touching the max-scores field; confirm it saves and `cf_max_scores` refits to the new count.
- [ ] Confirm OI and ACM contests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)