### PR TITLE
Fix duplicate class name in misc.py

### DIFF
--- a/vj4/handler/misc.py
+++ b/vj4/handler/misc.py
@@ -10,7 +10,7 @@ class AboutHandler(base.Handler):
 
 
 @app.route('/wiki/help', 'wiki_help', global_route=True)
-class AboutHandler(base.Handler):
+class WikiHelpHandler(base.Handler):
   async def get(self):
     self.render('wiki_help.html')
 


### PR DESCRIPTION
## Summary

- Renamed the second `AboutHandler` to `WikiHelpHandler`.
- Removed duplicate class-name shadowing in `vj4/handler/misc.py`.

## Testing

- Ran `python3 -m py_compile vj4/handler/misc.py`
- Ran `git diff --check`

Closes #100