### PR TITLE
Fix Bengali timeago locale

### DIFF
--- a/vj4/locale/bn.yaml
+++ b/vj4/locale/bn.yaml
@@ -59,7 +59,7 @@ domain_manage_join_applications: যোগদান আবেদন
 domain_manage_role: ডোমেইন রোলসমূহ
 domain_manage_user: ডোমেইন ব্যবহারকারী
 domain_manage_permission: ডোমেইন অনুমতি
-timeago_locale: en_US
+timeago_locale: bn_IN
 perm_general: সাধারণ
 perm_problem: সমস্যা
 perm_record: রেকর্ড


### PR DESCRIPTION
## Summary

- Updated `timeago_locale` in the Bengali locale file from `en_US` to `bn_IN`.
- Replaced the English fallback with the supported Bengali locale.

## Testing

- Verified the locale value in `vj4/locale/bn.yaml`.
- Ran `git diff --check`.

Closes #101